### PR TITLE
Improved property test coverage and found bugs

### DIFF
--- a/common/src/test/java/com/cldellow/manu/common/IntVectorTest.java
+++ b/common/src/test/java/com/cldellow/manu/common/IntVectorTest.java
@@ -62,8 +62,8 @@ public class IntVectorTest {
     }
 
     @Property
-    public void testLikeArray(int[] ints) {
-        IntVector iv = new IntVector();
+    public void testLikeArray(int[] ints, boolean grow) {
+        IntVector iv = grow ? new IntVector(1) : new IntVector();
         for (int i = 0; i < ints.length; i++) {
             assertEquals(i, iv.getSize());
             iv.add(ints[i]);

--- a/format/src/test/java/com/cldellow/manu/format/LengthOpsTest.java
+++ b/format/src/test/java/com/cldellow/manu/format/LengthOpsTest.java
@@ -53,7 +53,15 @@ public class LengthOpsTest {
 
 
     @Property
-    public void decodeIdAnyLen(@InRange(min = "0", max = "63") int id, @InRange(min = "0") int len) {
+    public void decodeIdAnyLen(@InRange(min = "0", max = "63") int id, @InRange(min = "0", max = "254") int smallLen, @InRange(min = "255", max = "65534") int mediumLen,  @InRange(min = "65535") int largeLen,  @InRange(min = "0", max = "2") int lenSelect) {
+        int len;
+
+        switch (lenSelect) {
+            case 2: len = largeLen;  break;
+            case 1: len = mediumLen; break;
+            case 0: len = smallLen;  break;
+            default: throw new Error("Dead code");
+        }
         byte encoded = LengthOps.encode((byte) id, len);
         assertEquals(id, LengthOps.decodeId(encoded));
 


### PR DESCRIPTION
Hi!

In an effort to improve the coverage of the property tests in this project, this PR found a few bugs:

* By ensuring a better distribution of the numbers generated in `LengthOpsTest.decodeIdAnyLen`, the property test is now able to find examples that violate assertions:
```
Caused by: java.lang.AssertionError: expected:<49193> but was:<-16343>                                                                                                                                              
        at org.junit.Assert.fail(Assert.java:88)                                                                                                                                                                    
        at org.junit.Assert.failNotEquals(Assert.java:834)                                                                                                                                                          
        at org.junit.Assert.assertEquals(Assert.java:645)                                                                                                                                                           
        at org.junit.Assert.assertEquals(Assert.java:631)                                                                                                                                                           
        at com.cldellow.manu.format.LengthOpsTest.decodeIdAnyLen(LengthOpsTest.java:78) 
```
* By using different implementations of encoders on test `ReaderTest.testVariableSize512`, the property test is able to find an assertion violation:
```
Caused by: junit.framework.AssertionFailedError: expected:<811930252> but was:<12>                                                                                                                                  
        at junit.framework.Assert.fail(Assert.java:57)                                                                                                                                                              
        at junit.framework.Assert.failNotEquals(Assert.java:329)                                                                                                                                                    
        at junit.framework.Assert.assertEquals(Assert.java:78)                                                                                                                                                      
        at junit.framework.Assert.assertEquals(Assert.java:234)                                                                                                                                                     
        at junit.framework.Assert.assertEquals(Assert.java:241)                                                                                                                                                     
        at junit.framework.TestCase.assertEquals(TestCase.java:409)                                                                                                                                                 
        at com.cldellow.manu.format.ReaderTest.testVariableSize(ReaderTest.java:255)                                                                                                                                
        at com.cldellow.manu.format.ReaderTest.testVariableSizes(ReaderTest.java:177)                                                                                                                               
        at com.cldellow.manu.format.ReaderTest.testVariableSize512(ReaderTest.java:188)  
```
* Increases the coverage on `IntVectorTest.testLikeArray` by ensuring the case where the array grows is included in the property